### PR TITLE
Add TCC & Permissions Tools section with FDA Tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,10 @@
 - [3uTools](http://www.3u.com/) - An All-in-One management software for iOS devices.
 - [iTools](https://www.thinkskysoft.com/itools/) - An All-in-One solution for iOS devices management.
 
+### TCC & Permissions Tools
+
+- [MacOS-Full-Disk-Access-Tunnel](https://github.com/civillizard/MacOS-Full-Disk-Access-Tunnel) - Grant Full Disk Access to interpreter binaries (Python, Node, Ruby) so launchd and cron scripts can read TCC-protected data like Safari history, cookies, and Photos metadata.
+
 ### Frida
 
 - [FridaSwiftDump](https://github.com/neil-wu/FridaSwiftDump/) - A Frida script for retriving the Swift Object info from an running app.


### PR DESCRIPTION
Adds a new **TCC & Permissions Tools** subsection under Tools, with the first entry:

[MacOS-Full-Disk-Access-Tunnel](https://github.com/civillizard/MacOS-Full-Disk-Access-Tunnel) — grants Full Disk Access to interpreter binaries (Python, Node, Ruby) so launchd and cron scripts can read TCC-protected data like Safari history, cookies, and Photos metadata.

TCC (Transparency, Consent, and Control) is a core macOS security mechanism, and tools for working with it are currently missing from this list. This new subsection fills that gap.

- Open-source (MIT license)
- Placed between Static Analysis Tools and Frida sections